### PR TITLE
feat: website settings

### DIFF
--- a/.project/known-issues.md
+++ b/.project/known-issues.md
@@ -5,3 +5,5 @@
 - we have buefy and bootstrap vue mixed, lets resolve that
 
 - 'index.js' is not resolved as the default file in the project (at least for management UI)
+
+- when developing the fabricated ui locally we have to account for the url not containing a valid id

--- a/.project/known-issues.md
+++ b/.project/known-issues.md
@@ -3,3 +3,5 @@
 - In our cloud function `sendEmail` we can't set the sender of the email to anyone but the transport account (`holistic.web.mailer@gmail.com`)
 
 - we have buefy and bootstrap vue mixed, lets resolve that
+
+- 'index.js' is not resolved as the default file in the project (at least for management UI)

--- a/.project/roadmap.md
+++ b/.project/roadmap.md
@@ -21,6 +21,8 @@
 
 - toasts should be abstracted behind a toastservice
 
+- we seem to be using the same stores in multiple UIs. Maybe it's worth keeping these in a centralised location
+
 ## Cloud Functions
 - for setUpNewAccount we should keep the default values for portfolio and website objects in their own files
 

--- a/.project/roadmap.md
+++ b/.project/roadmap.md
@@ -2,6 +2,8 @@
 
 ## Fabricated Website
 
+- could use a default layout component
+
 - pre render the fabricated website to static files with a tool like Nuxt.js
 
 - support displaying the fabricated website on custom urls

--- a/.project/roadmap.md
+++ b/.project/roadmap.md
@@ -19,6 +19,8 @@
 
 - store messages sent to user in a database and provide inbox and notification functionality
 
+- toasts should be abstracted behind a toastservice
+
 ## Cloud Functions
 - for setUpNewAccount we should keep the default values for portfolio and website objects in their own files
 

--- a/.project/roadmap.md
+++ b/.project/roadmap.md
@@ -17,6 +17,8 @@
 
 - store messages sent to user in a database and provide inbox and notification functionality
 
+## Cloud Functions
+- for setUpNewAccount we should keep the default values for portfolio and website objects in their own files
 
 ## Other Services
 

--- a/.project/roadmap.md
+++ b/.project/roadmap.md
@@ -13,6 +13,8 @@
 	- Let a custom vue component be rendered in the site
 	- Allow the user to choose the site colours
 
+- get information required for fabricated website from single firebase function
+
 ## Admin UI
 
 - store messages sent to user in a database and provide inbox and notification functionality

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## Relevant Links
 - https://console.firebase.google.com/u/0/project/actions-codelab-edeb1/overview
-    _firebase console_
+	_firebase console_
 - https://actions-codelab-edeb1.firebaseapp.com/
-    _fabricated website
+	_fabricated website
 - https://portfolio-administration.web.app/log-in
-    _portfolio admin_
+	_portfolio admin_
 
 ## Overview
 This is a tool to allow users to store their personal information (i.e. education, work experience) in a single location and easily export it to other sources.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a tool to allow users to store their personal information (i.e. educatio
 The project roadmap defining neat future feature ideas can be found in [roadmap.md](/.project/roadmap.md).
 
 ## Architecture
+- **Project Info**: project roadmap and currently known issues [/.project](/.project)
 - **Management UI**: manages portfolio objects and more info can be found in [/management-ui](/management-ui)
 - **Fabricated Website**: generates a user's website and more info can be found in [/fabricated-website](/fabricated-website)
 - **Database**: configures the schemas and indexes for the database [/database](/database)

--- a/cloud-functions/README.md
+++ b/cloud-functions/README.md
@@ -9,8 +9,8 @@ Functions can be deployed by:
 
 ## Functions
 
-### `createPortfolioOnNewAccount`
-This function creates a portfolio object under a user's `uid`. It's triggered whenever a new user sign's up to our service.
+### `setUpNewAccount`
+This function creates a portfolio and a website object under a user's `uid`. It's triggered whenever a new user signs up to our service.
 
 ### `sendEmail`
 This is a callable function that sends an email using nodemailer. It uses the gmail account `holistic.web.mailer@gmail.com` and the password is set as an environment variable in firebase.

--- a/cloud-functions/functions/index.js
+++ b/cloud-functions/functions/index.js
@@ -1,22 +1,43 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const nodemailer = require('nodemailer');
-
 admin.initializeApp(functions.config().firebase);
 
 // Create and Deploy Your First Cloud Functions
 // https://firebase.google.com/docs/functions/write-firebase-functions
 
-exports.createPortfolioOnNewAccount = functions.auth.user().onCreate(async (user) => {
-	console.log('> createPortfolioOnNewAccount called with: ' + JSON.stringify(user, null, 4));
+exports.setUpNewAccount = functions.auth.user().onCreate(async (user) => {
+	console.log('> setUpNewAccount called with: ' + JSON.stringify(user, null, 4));
 	const uid = user.uid;
+
+	// create the portfolio object
 	const email = user.email;
 	const portfolioCollection = admin.firestore().collection('portfolios');
 	await portfolioCollection.doc(uid).set({
+		name: {
+			first: null,
+			last: null
+		},
+		profession: null,
+		aboutMe: null,
+		profileImageUrl: null,
 		contact: {
-			email: email
+			email: email,
+			telephone: null
+		},
+		externalProfiles: {},
+		education: [],
+		experience: []
+	});
+
+	// create the website settings object
+	const websiteCollection = admin.firestore().collection('websites');
+	await websiteCollection.doc(uid).set({
+		settings: {
+			showContactForm: true
 		}
 	});
+
 });
 
 exports.sendEmail = functions.https.onCall(async (emailData, context) => {

--- a/cloud-functions/functions/package.json
+++ b/cloud-functions/functions/package.json
@@ -11,7 +11,8 @@
 	"dependencies": {
 		"firebase-admin": "~7.0.0",
 		"firebase-functions": "^2.2.0",
-		"nodemailer": "^6.2.1"
+		"lodash": "4.17.11",
+		"nodemailer": "6.2.1"
 	},
 	"private": true,
 	"engines": {

--- a/database/firestore.rules
+++ b/database/firestore.rules
@@ -9,5 +9,9 @@ service cloud.firestore {
 		match /portfolios/{key} {
 			allow write: if request.auth.uid == key;
 		}
+
+		match /websites/{key} {
+			allow write: if request.auth.uid == key;
+		}
 	}
 }

--- a/fabricated-website/package-lock.json
+++ b/fabricated-website/package-lock.json
@@ -3382,8 +3382,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "coa": {
       "version": "2.0.2",
@@ -6714,8 +6713,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6736,14 +6734,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6758,20 +6754,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6888,8 +6881,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6901,7 +6893,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6916,7 +6907,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6924,14 +6914,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6950,7 +6938,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7031,8 +7018,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7044,7 +7030,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7130,8 +7115,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7167,7 +7151,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7187,7 +7170,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7231,14 +7213,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -12695,8 +12675,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",

--- a/fabricated-website/src/App.vue
+++ b/fabricated-website/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-	<div id="app" v-if="portfolio">
+	<div id="app" v-if="!isLoading">
 
 		<vue-headful :title="`${portfolio.name.first} ${portfolio.name.last}`"/>
 		<contact-modal
@@ -42,6 +42,7 @@ export default {
 	},
 	data() {
 		return {
+			isLoading: false,
 			isModalVisible: false
 		};
 	},
@@ -52,7 +53,8 @@ export default {
 	},
 	methods: {
 		...mapActions({
-			fetchPortfolioById: 'portfolio/fetchPortfolioById'
+			fetchPortfolioById: 'portfolio/fetchPortfolioById',
+			fetchWebsiteById: 'website/fetchWebsiteById'
 		}),
 		showModal() {
 			this.isModalVisible = true;
@@ -62,8 +64,13 @@ export default {
 		}
 	},
 	async created() {
+		this.isLoading = true;
 		const id = window.location.pathname.substring(1);
-		await this.fetchPortfolioById({ id });
+		await Promise.all([
+			this.fetchPortfolioById({ id }),
+			this.fetchWebsiteById({ id })
+		]);
+		this.isLoading = false;
 	}
 };
 

--- a/fabricated-website/src/components/AppHeader.vue
+++ b/fabricated-website/src/components/AppHeader.vue
@@ -11,6 +11,7 @@
 			</span>
 
 			<b-button
+				v-if="website.settings.showContactForm"
 				class="Header__contactButton"
 				variant="outline-primary"
 				size="lg"
@@ -34,7 +35,8 @@ export default {
 	},
 	computed: {
 		...mapGetters({
-			portfolio: 'portfolio/portfolio'
+			portfolio: 'portfolio/portfolio',
+			website: 'website/website'
 		}),
 		headerShadowClassName() {
 			if (this.scrollDistance > 10) return 'Header--shadow';

--- a/fabricated-website/src/store/index.js
+++ b/fabricated-website/src/store/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 import firebase from 'firebase';
 import config from '../config';
+import websiteStore from './modules/website';
 import portfolioStore from './modules/portfolio';
 import emailStore from './modules/email';
 
@@ -17,6 +18,7 @@ const storeConfig = {
 		functions
 	},
 	modules: {
+		website: websiteStore,
 		portfolio: portfolioStore,
 		email: emailStore
 	}

--- a/fabricated-website/src/store/modules/website.js
+++ b/fabricated-website/src/store/modules/website.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-param-reassign */
+import { get as _get } from 'lodash';
+
+export default {
+	namespaced: true,
+	state: {
+		website: null
+	},
+	mutations: {
+		SET_WEBSITE(state, response) {
+			state.website = response;
+		}
+	},
+	actions: {
+		async fetchWebsiteById({ commit, rootState }, { id, options }) {
+			const websiteRef = rootState.db.collection('websites').doc(id);
+			const websiteDoc = await websiteRef.get();
+			const website = websiteDoc.data();
+			if (!_get(options, 'skipCommit')) commit('SET_WEBSITE', website);
+			return website;
+		}
+	},
+	getters: {
+		website: state => state.website
+	}
+};

--- a/management-ui/package-lock.json
+++ b/management-ui/package-lock.json
@@ -12961,11 +12961,6 @@
         }
       }
     },
-    "vue-form-generator": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/vue-form-generator/-/vue-form-generator-2.3.4.tgz",
-      "integrity": "sha512-gkGLukX2xyVYASVopRVt/v4ZVFpoH+I1j+yRIkJBOR9++UwZTi8yREWydnKukpp/r90SGX68Yzy4OkQrKZHluQ=="
-    },
     "vue-functional-data-merge": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-2.0.7.tgz",

--- a/management-ui/src/App.vue
+++ b/management-ui/src/App.vue
@@ -28,4 +28,12 @@ export default {
 	text-align: center;
 	color: #2c3e50;
 }
+
+/* Bootstrap Vue Customisation */
+// radio buttons that are clickable have mouse cursor
+.btn-group-toggle {
+	> label:not(.active) {
+		cursor: pointer !important;
+	}
+}
 </style>

--- a/management-ui/src/components/AppHeader.vue
+++ b/management-ui/src/components/AppHeader.vue
@@ -8,13 +8,18 @@
 
 					<b-nav class="AppHeader__menu">
 						<b-nav-item class="AppHeader__menu__item">
-							<router-link class="AppHeader__menu__link" :to="{ name: 'portfolio.detail' }">Portfolio</router-link>
+
+							<router-link
+								class="AppHeader__menu__link"
+								:to="{ name: 'portfolio.detail' }"
+								v-text="'Portfolio'"/>
+
+							<router-link
+								class="AppHeader__menu__link"
+								:to="{ name: 'website.detail' }"
+								v-text="'Website'"/>
+
 						</b-nav-item>
-						<b-dropdown text="Primary" variant="primary" class="m-2">
-							<b-dropdown-item href="#">Action</b-dropdown-item>
-							<b-dropdown-item href="#">Another action</b-dropdown-item>
-							<b-dropdown-item href="#">Something else here</b-dropdown-item>
-						</b-dropdown>
 					</b-nav>
 
 					<b-btn

--- a/management-ui/src/containers/website/Detail.vue
+++ b/management-ui/src/containers/website/Detail.vue
@@ -1,0 +1,63 @@
+<template>
+	<section class="WebsiteDetail">
+
+		<h1>Website</h1>
+
+		<router-link :to="{ name: 'website.edit' }">
+			<b-btn v-text="'Edit'" variant="info"/>
+		</router-link>
+
+		<p>Your website can be viewed at <a :href="websiteUrl" v-text="websiteUrl" target="_blank"/></p>
+
+		<span v-if="!website" class="text-error">There was a problem loading your website.</span>
+
+		<template v-else>
+			<pre class="WebsiteDetail__detail"> {{ JSON.stringify(website, null, 4) }} </pre>
+		</template>
+
+	</section>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex';
+
+export default {
+	data() {
+		return {
+			errorText: null
+		};
+	},
+	computed: {
+		...mapGetters({
+			website: 'website/website',
+			authentication: 'account/authentication'
+		}),
+		websiteUrl() {
+			const { uid } = this.authentication.user;
+			return `https://actions-codelab-edeb1.firebaseapp.com/${uid}`;
+		}
+	},
+	methods: {
+		...mapActions({
+			fetchWebsite: 'website/fetchWebsite'
+		})
+	},
+	created() {
+		this.fetchWebsite();
+	}
+};
+</script>
+
+<style lang="scss">
+
+.PortfolioDetail {
+	padding: 1rem;
+	display: flex;
+	flex-direction: column;
+
+	&__detail {
+		text-align: left;
+	}
+}
+
+</style>

--- a/management-ui/src/containers/website/Edit.vue
+++ b/management-ui/src/containers/website/Edit.vue
@@ -1,0 +1,113 @@
+<template>
+	<section class="WebsiteEdit">
+
+		<h1>Website</h1>
+
+		<router-link :to="{ name: 'website.detail' }">
+			<b-btn variant="info" v-text="'detail'"/>
+		</router-link>
+
+		<span
+			v-if="page.isLoading"
+			v-text="'Loading...'"/>
+
+		<span
+			v-if="page.isSubmitting"
+			v-text="'Submitting...'"/>
+
+		<section v-if="!page.isLoading && !page.isSubmitting">
+
+			<b-form-group
+				v-if="!page.isSubmitting"
+				label="Show Contact Form"
+				for="WebsiteEdit__showContactForm">
+				<b-form-radio-group
+					id="WebsiteEdit__showContactForm"
+					v-model="websiteData.settings.showContactForm"
+					:options="[true, false]"
+					size="lg"
+					button-variant="outline-info"
+					buttons
+					stacked/>
+			</b-form-group>
+
+		</section>
+
+		<b-btn
+			variant="outline-primary"
+			:disabled="isSubmitButtonDisabled"
+			@click="onSubmitClick"
+			v-text="'Submit'"/>
+
+	</section>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+
+export default {
+	data() {
+		return {
+			page: {
+				isLoading: false,
+				isSubmitting: false
+			},
+			websiteData: null
+		};
+	},
+	computed: {
+		...mapGetters({
+			website: 'website/website'
+		}),
+		isSubmitButtonDisabled() {
+			if (
+				this.page.isSubmitting
+				|| !this.websiteData
+			) return true;
+			return false;
+		}
+	},
+	methods: {
+		...mapActions({
+			fetchWebsite: 'website/fetchWebsite',
+			updateWebsite: 'website/updateWebsite'
+		}),
+		async fetch() {
+			this.page.isLoading = true;
+			await this.fetchWebsite();
+			this.websiteData = this.website;
+			this.page.isLoading = false;
+		},
+		async onSubmitClick() {
+			this.page.isSubmitting = true;
+			await this.updateWebsite(this.websiteData);
+			this.$toasted.show('Website Updated', {
+				position: 'bottom-right',
+				duration: '3000'
+			});
+			this.page.isSubmitting = false;
+		}
+	},
+	watch: {
+		website: {
+			immediate: true,
+			handler() {
+				this.formData = this.website;
+			}
+		}
+	},
+	created() {
+		this.fetch();
+	}
+};
+</script>
+
+<style lang="scss">
+
+.WebsiteEdit {
+	padding: 1rem;
+	display: flex;
+	flex-direction: column;
+}
+
+</style>

--- a/management-ui/src/containers/website/Edit.vue
+++ b/management-ui/src/containers/website/Edit.vue
@@ -75,7 +75,6 @@ export default {
 		async fetch() {
 			this.page.isLoading = true;
 			await this.fetchWebsite();
-			this.websiteData = this.website;
 			this.page.isLoading = false;
 		},
 		async onSubmitClick() {
@@ -92,7 +91,7 @@ export default {
 		website: {
 			immediate: true,
 			handler() {
-				this.formData = this.website;
+				this.websiteData = this.website;
 			}
 		}
 	},

--- a/management-ui/src/containers/website/Edit.vue
+++ b/management-ui/src/containers/website/Edit.vue
@@ -18,7 +18,6 @@
 		<section v-if="!page.isLoading && !page.isSubmitting">
 
 			<b-form-group
-				v-if="!page.isSubmitting"
 				label="Show Contact Form"
 				for="WebsiteEdit__showContactForm">
 				<b-form-radio-group

--- a/management-ui/src/containers/website/index.js
+++ b/management-ui/src/containers/website/index.js
@@ -1,0 +1,17 @@
+import Detail from './Detail.vue';
+import Edit from './Edit.vue';
+
+const routes = [
+	{
+		name: 'website.detail',
+		path: '/website',
+		component: Detail
+	},
+	{
+		name: 'website.edit',
+		path: '/website/edit',
+		component: Edit
+	}
+];
+
+export default routes;

--- a/management-ui/src/router/routes.js
+++ b/management-ui/src/router/routes.js
@@ -1,9 +1,11 @@
 import authenticationRoutes from '../containers/authentication/index';
 import portfolioRoutes from '../containers/portfolio/index';
+import websiteRoutes from '../containers/website/index';
 
 const routes = [
 	...authenticationRoutes,
 	...portfolioRoutes,
+	...websiteRoutes,
 	{
 		path: '*',
 		redirect: { name: 'portfolio.detail' }

--- a/management-ui/src/store/index.js
+++ b/management-ui/src/store/index.js
@@ -5,6 +5,7 @@ import VuexPersistence from 'vuex-persist';
 import config from '../config';
 import accountStore from './modules/account';
 import portfolioStore from './modules/portfolio';
+import websiteStore from './modules/website';
 
 Vue.use(Vuex);
 
@@ -25,7 +26,8 @@ const storeConfig = {
 	},
 	modules: {
 		account: accountStore,
-		portfolio: portfolioStore
+		portfolio: portfolioStore,
+		website: websiteStore
 	},
 	plugins: [
 		persistedState.plugin

--- a/management-ui/src/store/modules/website.js
+++ b/management-ui/src/store/modules/website.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-param-reassign */
+export default {
+	namespaced: true,
+	state: {
+		website: null
+	},
+	mutations: {
+		SET_WEBSITE(state, website) {
+			state.website = website;
+		}
+	},
+	actions: {
+		/**
+		 * fetches the website stored under the user's uuuserId
+		 * @returns the porfolio object
+		 */
+		async fetchWebsite({ commit, rootState }) {
+			const userId = rootState.account.authentication.user.uid;
+			const websiteRef = rootState.db.collection('websites').doc(userId);
+			const websiteDoc = await websiteRef.get();
+			if (!websiteDoc.exists) throw new Error('website does not exist');
+			const website = websiteDoc.data();
+			commit('SET_WEBSITE', website);
+			return website;
+		},
+		async updateWebsite({ dispatch, rootState }, websiteUpdate) {
+			const userId = rootState.account.authentication.user.uid;
+			const websiteRef = rootState.db.collection('websites').doc(userId);
+			const updateResult = await websiteRef.update(websiteUpdate);
+			await dispatch('fetchWebsite');
+			return updateResult;
+		}
+	},
+	getters: {
+		website: state => state.website
+	}
+};


### PR DESCRIPTION
This Pull request adds a section to the management UI for a user to edit their website settings. It allows a user to select whether they can be emailed with a contact form with the config:
```
{
    settings: {
        showContactForm: true
    }
}
```

It is part of the work effort outlined in #11 

## Changes
### Features
- new website container in the management-ui to allow editing and viewing website settings
- on new account firebase listener now also creates a new website object
- allowed users to write to the website object with id matching their account
- hid open contact modal button in fabricated website if `settings.showContactForm` is `false`
### Chores
- ensured all users have valid portfolio and wesbite objects

## Before Merging
- [x] run `git pull origin development`
- [x] deploy the management ui changes
- [x] deploy the fabricated website changes