### PR TITLE
Fix the forms on the edit page

### DIFF
--- a/management-ui/package-lock.json
+++ b/management-ui/package-lock.json
@@ -3165,7 +3165,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "coa": {
       "version": "2.0.2",
@@ -5682,7 +5683,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5703,12 +5705,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5723,17 +5727,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5850,7 +5857,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5862,6 +5870,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5876,6 +5885,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5883,12 +5893,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5907,6 +5919,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5987,7 +6000,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5999,6 +6013,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6084,7 +6099,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6120,6 +6136,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6139,6 +6156,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6182,12 +6200,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8210,8 +8230,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -10993,7 +11012,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
@@ -12960,11 +12980,6 @@
           }
         }
       }
-    },
-    "vue-form-generator": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/vue-form-generator/-/vue-form-generator-2.3.4.tgz",
-      "integrity": "sha512-gkGLukX2xyVYASVopRVt/v4ZVFpoH+I1j+yRIkJBOR9++UwZTi8yREWydnKukpp/r90SGX68Yzy4OkQrKZHluQ=="
     },
     "vue-functional-data-merge": {
       "version": "2.0.7",

--- a/management-ui/package.json
+++ b/management-ui/package.json
@@ -12,7 +12,7 @@
     "buefy": "^0.7.7",
     "core-js": "^2.6.5",
     "firebase": "^6.1.0",
-    "lodash": "^4.17.11",
+    "lodash": "4.17.11",
     "vue": "^2.6.10",
     "vue-icon": "^2.1.1",
     "vue-json-schema-form": "^1.0.4",

--- a/management-ui/package.json
+++ b/management-ui/package.json
@@ -12,6 +12,7 @@
     "buefy": "^0.7.7",
     "core-js": "^2.6.5",
     "firebase": "^6.1.0",
+    "lodash": "^4.17.11",
     "vue": "^2.6.10",
     "vue-icon": "^2.1.1",
     "vue-json-schema-form": "^1.0.4",

--- a/management-ui/src/containers/portfolio/Edit.vue
+++ b/management-ui/src/containers/portfolio/Edit.vue
@@ -15,16 +15,180 @@
 			v-if="page.isSubmitting"
 			v-text="'Submitting...'"/>
 
-		<section v-if="!page.isLoading && !page.isSubmitting && portfolioData">
+		<section v-if="!page.isLoading && !page.isSubmitting">
 
-			<b-form-group
-				label="Name:"
-				label-align-sm="middle"
-				label-for="Portfolio__name">
-				<b-form-input
-					id="Portfolio__name"
-					v-model="portfolioData.name.first"/>
-			</b-form-group>
+			<section>
+
+				<label class="PortfolioEdit__label">Name</label>
+
+				<b-form-group
+					label="First name:"
+					label-for="Portfolio__firstName">
+					<b-form-input
+						id="Portfolio__firstName"
+						v-model="portfolioData.name.first"/>
+				</b-form-group>
+
+				<b-form-group
+					label="Last name:"
+					label-for="Portfolio__lastName">
+					<b-form-input
+						id="Portfolio__lastName"
+						v-model="portfolioData.name.last"/>
+				</b-form-group>
+
+			</section>
+
+			<section>
+
+				<label class="PortfolioEdit__label">Profession</label>
+
+				<b-form-group
+					label="Profession:"
+					label-for="Portfolio__profession">
+					<b-form-input
+						id="Portfolio__profession"
+						v-model="portfolioData.profession"/>
+				</b-form-group>
+
+			</section>
+
+			<section>
+
+				<label class="PortfolioEdit__label">About Me</label>
+
+				<b-form-group
+					label="Profession:"
+					label-for="Portfolio__profession">
+					<b-form-input
+						id="Portfolio__profession"
+						v-model="portfolioData.aboutMe"/>
+				</b-form-group>
+
+			</section>
+
+			<section>
+
+				<label class="PortfolioEdit__label">Profile Image</label>
+
+				<b-form-group
+					label="Profile Image URL:"
+					label-for="Portfolio__profileImageUrl">
+					<b-form-input
+						id="Portfolio__profileImageUrl"
+						v-model="portfolioData.profileImageUrl"/>
+				</b-form-group>
+
+			</section>
+
+			<section>
+
+				<label class="PortfolioEdit__label">Contact</label>
+
+				<b-form-group
+					label="Contact email:"
+					label-for="Portfolio__contactEmail">
+					<b-form-input
+						id="Portfolio__contactEmail"
+						v-model="portfolioData.contact.email"/>
+				</b-form-group>
+
+				<b-form-group
+					label="Contact telephone:"
+					label-for="Portfolio__contactTelephone">
+					<b-form-input
+						id="Portfolio__contactTelephone"
+						v-model="portfolioData.contact.telephone"/>
+				</b-form-group>
+
+			</section>
+
+			<section>
+
+				<label class="PortfolioEdit__label">External Profiles</label>
+
+				<b-form-group
+					label="GitHub URL:"
+					label-for="Portfolio__Github">
+					<b-form-input
+						id="Portfolio__Github"
+						v-model="portfolioData.externalProfiles.github"/>
+				</b-form-group>
+
+				<b-form-group
+					label="LinkedIn URL:"
+					label-for="Portfolio__LinkedIn">
+					<b-form-input
+						id="Portfolio__LinkedIn"
+						v-model="portfolioData.externalProfiles.linkenIn"/>
+				</b-form-group>
+
+				<b-form-group
+					label="Stack Overflow URL:"
+					label-for="Portfolio__StackOverflow">
+					<b-form-input
+						id="Portfolio__StackOverflow"
+						v-model="portfolioData.externalProfiles.stackOverflow"/>
+				</b-form-group>
+
+			</section>
+
+			<section>
+
+				<label class="PortfolioEdit__label">Education</label>
+
+				<section class="PortfolioEdit__sublistItem"
+					v-for="(item, i) in portfolioData.education"
+					:key="i">
+
+					<code>Item {{i+1}}</code>
+
+					<b-form-group
+						label="Institution:"
+						label-for="Portfolio__educationInstitution">
+						<b-form-input
+							id="Portfolio__educationInstitution"
+							v-model="portfolioData.education[i].institution"/>
+					</b-form-group>
+
+					<b-form-group
+						label="Date:"
+						label-for="Portfolio__educationDate">
+						<b-form-input
+							id="Portfolio__educationDate"
+							v-model="portfolioData.education[i].date"/>
+					</b-form-group>
+
+					<section class="PortfolioEdit__subBlock">
+
+						<label>Qualifications:</label>
+						<b-form-input
+							class="PortfolioEdit__sublistItem"
+							v-for="(qualificationItem, j) in portfolioData.education[i].qualifications"
+							:key="j"
+							v-model="portfolioData.education[i].qualifications[j]"/>
+
+						<b-btn
+							size="sm"
+							variant="outline-primary"
+							@click="portfolioData.education[i].qualifications.push('')">Add Item</b-btn>
+
+					</section>
+
+				</section>
+
+				<b-btn
+					size="lg"
+					variant="outline-primary"
+					@click="portfolioData.education.push({ qualifications: [] })">Add Education</b-btn>
+
+			</section>
+
+			<section>
+
+				<label class="PortfolioEdit__label">Experience</label>
+
+			</section>
 
 		</section>
 
@@ -89,6 +253,22 @@ export default {
 	padding: 1rem;
 	display: flex;
 	flex-direction: column;
+
+	&__label {
+		text-align: left;
+		width: 100%;
+		font-weight: bold;
+	}
+
+	&__sublistItem {
+		margin-bottom: 1rem;
+	}
+
+	&__subBlock {
+		display: flex;
+		flex-direction: column;
+	}
+
 }
 
 </style>

--- a/management-ui/src/containers/portfolio/Edit.vue
+++ b/management-ui/src/containers/portfolio/Edit.vue
@@ -7,20 +7,44 @@
 			<b-btn variant="info" v-text="'detail'"/>
 		</router-link>
 
-		<schema-form v-if="portfolio" :schema="portfolioSchema" v-model="formData" @submit="onSubmitClick"/>
+		<span
+			v-if="page.isLoading"
+			v-text="'Loading...'"/>
+
+		<span
+			v-if="page.isSubmitting"
+			v-text="'Submitting...'"/>
+
+		<section v-if="!page.isLoading && !page.isSubmitting && portfolioData">
+
+			<b-form-group
+				label="Name:"
+				label-align-sm="middle"
+				label-for="Portfolio__name">
+				<b-form-input
+					id="Portfolio__name"
+					v-model="portfolioData.name.first"/>
+			</b-form-group>
+
+		</section>
 
 	</section>
 </template>
 
 <script>
 import { mapActions, mapGetters } from 'vuex';
+import { cloneDeep } from 'lodash';
 import portfolioSchema from '../../../../common/portfolio.schema.json';
 
 export default {
 	data() {
 		return {
+			page: {
+				isLoading: false,
+				isSubmitting: false
+			},
 			portfolioSchema,
-			formData: {}
+			portfolioData: null
 		};
 	},
 	computed: {
@@ -39,7 +63,6 @@ export default {
 				position: 'bottom-right',
 				duration: '3000'
 			});
-			console.log('done');
 		}
 	},
 	watch: {
@@ -50,8 +73,12 @@ export default {
 			}
 		}
 	},
-	created() {
-		this.fetchPortfolio();
+	async created() {
+		this.page.isLoading = true;
+		await this.fetchPortfolio();
+		this.portfolioData = cloneDeep(this.portfolio);
+		console.log('this.portfolioData: ', this.portfolioData);
+		this.page.isLoading = false;
 	}
 };
 </script>


### PR DESCRIPTION
This PR fixes forms on the edit page

## Changes

- Instead of using a schema, we now use a b-form-group in the Edit.vue HTML

## ToDo:

- move calculations and actions in the html into computed properties and methods respectively
- disable the add new qualification item button if the last item in the array is still an empty string
- add submit button
- give buttons colors with the bootstrap variant property
- allow user to submit portfolio to update it
- validate that user can only submit portfolio when all fields are valid